### PR TITLE
Fix return value for `multi`

### DIFF
--- a/lib/redis-slave-read/interface/base.rb
+++ b/lib/redis-slave-read/interface/base.rb
@@ -81,11 +81,13 @@ class Redis
         end
 
         def multi(*args, &block)
+          replies = nil
           @block_exec_mutex.synchronize do
             @locked_node = @master
-            @master.send(:multi, *args, &block)
+            replies = @master.send(:multi, *args, &block)
             @locked_node = nil
           end
+          replies
         end
 
         private

--- a/spec/interface/hiredis_spec.rb
+++ b/spec/interface/hiredis_spec.rb
@@ -40,6 +40,14 @@ describe Redis::SlaveRead::Interface::Hiredis do
         2.times { subject.get "foo" }
       end
     end
+
+    it "returns replies to all commands in multi block" do
+      results = subject.multi do
+        subject.set 'foo', 'bar'
+        subject.get 'foo'
+      end
+      expect(results).to eq(['OK', 'bar'])
+    end
   end
 
   context "when in a pipelined block" do

--- a/spec/interface/hiredis_spec.rb
+++ b/spec/interface/hiredis_spec.rb
@@ -58,6 +58,13 @@ describe Redis::SlaveRead::Interface::Hiredis do
         2.times { subject.get "foo" }
       end
     end
+
+    it "returns replies to all commands in pipelined block" do
+      results = subject.pipelined do
+        2.times { subject.set 'foo', 'bar' }
+      end
+      expect(results).to eq(['OK', 'OK'])
+    end
   end
 
   context "commands that distribute to all nodes" do


### PR DESCRIPTION
See https://github.com/cheald/redis-slave-read/pull/2 for details.  Merging to own fork for immediate use.
