### PR TITLE
Start round-robin with a random node

### DIFF
--- a/lib/redis-slave-read/interface/base.rb
+++ b/lib/redis-slave-read/interface/base.rb
@@ -44,7 +44,7 @@ class Redis
           @all = slaves + [@master]
           @nodes = slaves.dup
           @nodes.unshift @master if @read_master
-          @index = 0
+          @index = rand(@nodes.length)
         end
 
         def method_missing(method, *args)

--- a/spec/interface/hiredis_spec.rb
+++ b/spec/interface/hiredis_spec.rb
@@ -26,9 +26,9 @@ describe Redis::SlaveRead::Interface::Hiredis do
     it "should distribute reads between all available slaves" do
       expect(master).to receive(:get).never
       expect(slaves[1]).to receive(:get).twice
-      expect(slaves[0]).to receive(:get).once
+      expect(slaves[0]).to receive(:get).twice
 
-      3.times { subject.get "foo" }
+      4.times { subject.get "foo" }
     end
   end
 


### PR DESCRIPTION
Picks a random starting point for the round-robin distribution of read requests.  This allows a roughly even distribution even when a new Hiredis instance is created every time (such as in a web server that runs multiple processes/frontends).
